### PR TITLE
Add helper for empty metadata frames

### DIFF
--- a/asx_signal_provider.py
+++ b/asx_signal_provider.py
@@ -255,6 +255,29 @@ def get_metadata() -> pd.DataFrame:
     return _load_metadata()
 
 
+def _empty_metadata_frame(columns: Optional[Iterable[str]] = None) -> pd.DataFrame:
+    """Return an empty metadata frame with the expected columns and index."""
+
+    default_columns: Tuple[str, ...] = (
+        "ticker",
+        "name",
+        "sector",
+        "market_cap_billion",
+        "exchange",
+        "type",
+    )
+    resolved_columns: Tuple[str, ...] = tuple(columns) if columns is not None else default_columns
+    frame = pd.DataFrame(columns=resolved_columns)
+
+    if "ticker" in frame.columns:
+        frame = frame.set_index("ticker", drop=False)
+
+    if "market_cap_billion" in frame.columns:
+        frame["market_cap_billion"] = frame["market_cap_billion"].astype(float)
+
+    return frame
+
+
 def _call_with_optional_repair(
     func: Callable[..., pd.DataFrame],
     *,


### PR DESCRIPTION
## Summary
- add `_empty_metadata_frame` helper that returns a typed, indexed metadata DataFrame stub
- ensure the frame retains the ticker index and numeric market cap column for downstream operations

## Testing
- `python asx_signal_provider.py --run-tests` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e2ff3383848330afb3a8bb3db757c4