### PR TITLE
Support single-ticker override in Streamlit app

### DIFF
--- a/asx_signal_provider.py
+++ b/asx_signal_provider.py
@@ -882,6 +882,9 @@ def build_streamlit_app() -> None:
     cap_range: Optional[Tuple[float, float]] = None
     ticker_source = "ASX200 Universe"
     custom_ticker = ""
+    custom_symbol: str = ""
+    custom_display: str = ""
+    custom_override_active = False
 
     with st.sidebar:
         st.header("Universe & Filters")
@@ -908,9 +911,25 @@ def build_streamlit_app() -> None:
                 step=0.5,
             )
 
-            custom_ticker = st.text_input(
+            custom_input = st.text_input(
                 "Custom ticker override (optional)", value=""
             )
+            custom_ticker = custom_input.strip()
+            custom_symbol = ""
+            custom_display = ""
+            custom_override_active = False
+            if custom_ticker:
+                try:
+                    custom_symbol = normalize_ticker_symbol(
+                        custom_ticker, assume_exchange=DEFAULT_EXCHANGE
+                    )
+                    custom_display = format_display_ticker(
+                        custom_symbol, assume_exchange=DEFAULT_EXCHANGE
+                    )
+                    custom_override_active = True
+                except ValueError:
+                    st.error("Custom ticker is invalid. Please use a valid symbol.")
+                    custom_ticker = ""
 
             filtered_metadata = metadata[
                 metadata["sector"].isin(selected_sectors)
@@ -974,39 +993,27 @@ def build_streamlit_app() -> None:
         )
 
     if ticker_source == "ASX200 Universe":
-        if custom_ticker:
-            custom_ticker = custom_ticker.strip()
-            try:
-                custom_symbol = normalize_ticker_symbol(
-                    custom_ticker, assume_exchange=DEFAULT_EXCHANGE
+        if custom_override_active and custom_display:
+            if custom_display not in filtered_metadata.index:
+                new_row: Dict[str, object] = {
+                    "ticker": custom_display,
+                    "symbol": custom_symbol,
+                    "name": custom_display,
+                    "sector": "Custom",
+                    "market_cap_billion": np.nan,
+                    "exchange": DEFAULT_EXCHANGE,
+                    "type": "Equity",
+                }
+                addition = pd.DataFrame([new_row]).set_index("ticker", drop=False)
+                filtered_metadata = pd.concat(
+                    [filtered_metadata, addition], axis=0, sort=False
                 )
-                custom_display = format_display_ticker(
-                    custom_symbol, assume_exchange=DEFAULT_EXCHANGE
-                )
-            except ValueError:
-                custom_symbol = ""
-                custom_display = ""
-                st.error("Custom ticker is invalid. Please use a valid symbol.")
+            else:
+                filtered_metadata.loc[custom_display, "symbol"] = custom_symbol
 
-            if custom_display:
-                if custom_display not in filtered_metadata.index:
-                    new_row: Dict[str, object] = {
-                        "ticker": custom_display,
-                        "symbol": custom_symbol,
-                        "name": custom_display,
-                        "sector": "Custom",
-                        "market_cap_billion": np.nan,
-                        "exchange": DEFAULT_EXCHANGE,
-                        "type": "Equity",
-                    }
-                    addition = pd.DataFrame([new_row]).set_index("ticker", drop=False)
-                    filtered_metadata = pd.concat(
-                        [filtered_metadata, addition], axis=0, sort=False
-                    )
-                else:
-                    filtered_metadata.loc[custom_display, "symbol"] = custom_symbol
-
-        if cap_range is not None:
+        if custom_override_active and custom_display:
+            st.write(f"Scanning custom ticker **{custom_display}**.")
+        elif cap_range is not None:
             st.write(
                 "Scanning **{count}** tickers between {low:.1f} and {high:.1f} "
                 "billion AUD.".format(
@@ -1041,6 +1048,19 @@ def build_streamlit_app() -> None:
         for ticker in filtered_metadata["ticker"].tolist()
         if isinstance(ticker, str) and ticker.strip()
     ]
+
+    if custom_override_active:
+        if custom_symbol:
+            tickers_to_scan = [custom_symbol]
+        else:
+            try:
+                custom_symbol = normalize_ticker_symbol(
+                    custom_ticker, assume_exchange=DEFAULT_EXCHANGE
+                )
+                tickers_to_scan = [custom_symbol]
+            except ValueError:
+                st.error("Invalid custom ticker format.")
+                tickers_to_scan = []
 
     scan_params = {
         "tickers": tuple(tickers_to_scan),


### PR DESCRIPTION
## Summary
- normalize the custom ticker override and only enqueue that symbol when provided
- surface a UI message for the custom selection and ensure metadata reflects the ad-hoc ticker

## Testing
- python asx_signal_provider.py --run-tests *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e346e46cd88330bf55ce360db5c0b2